### PR TITLE
Timeout remove

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.1.9
+
+* `NetworkRequestTimeout` removed — request timeouts are now treated as a
+  loss of connection and emit `NetworkConnectionLost` directly. This lets
+  the offline mode activate even for silent/background requests without an
+  extra reachability check.
+* `NetworkServiceBase`: removed timeout-triggered ping fallback that became
+  redundant after the change above.
+
 ## 0.1.8
 
 * `RequestServiceBase`: request timeouts (`shortTimeout`, `normalTimeout`,

--- a/lib/data/remote/const/network_event.dart
+++ b/lib/data/remote/const/network_event.dart
@@ -19,16 +19,12 @@ final class NetworkRestore extends NetworkEvent {
   NetworkRestore({super.data});
 }
 
-/// There is no internet connection or backend is down
+/// There is no internet connection or backend is down. Also emitted on
+/// request timeouts — a timeout from the backend is treated as a temporary
+/// loss of connection and triggers the offline mode.
 final class NetworkConnectionLost extends NetworkEvent {
   ///
   NetworkConnectionLost({super.data});
-}
-
-/// Request cancelled by timeout
-final class NetworkRequestTimeout extends NetworkEvent {
-  ///
-  NetworkRequestTimeout({super.data});
 }
 
 /// Got 401 HTTP status

--- a/lib/data/remote/service/request_service_base.dart
+++ b/lib/data/remote/service/request_service_base.dart
@@ -151,9 +151,12 @@ abstract base class RequestServiceBase {
       notify(NetworkSuccess(), silence: request.silence);
       return response;
     } on TimeoutException {
-      /// Time is out
+      /// Request didn't complete in time — treat it the same way as a lost
+      /// connection: backend is effectively unreachable from the user's
+      /// perspective, so switch to offline mode. Bypass the `silence` flag
+      /// because connection state is global.
       logRequestInfo(request: request, info: 'Timeout exception');
-      notify(NetworkRequestTimeout(), silence: request.silence);
+      _networkSubject.add(NetworkConnectionLost());
     } on SocketException catch (error) {
       /// SocketException means we could not even establish a socket
       /// (DNS lookup failure, route unreachable, connection refused, etc.).

--- a/lib/data/remote/service/request_service_base.dart
+++ b/lib/data/remote/service/request_service_base.dart
@@ -156,7 +156,7 @@ abstract base class RequestServiceBase {
       /// perspective, so switch to offline mode. Bypass the `silence` flag
       /// because connection state is global.
       logRequestInfo(request: request, info: 'Timeout exception');
-      _networkSubject.add(NetworkConnectionLost());
+      notify(NetworkConnectionLost());
     } on SocketException catch (error) {
       /// SocketException means we could not even establish a socket
       /// (DNS lookup failure, route unreachable, connection refused, etc.).

--- a/lib/presentation/service/network_service_base.dart
+++ b/lib/presentation/service/network_service_base.dart
@@ -68,6 +68,8 @@ abstract base class NetworkServiceBase {
 
   ///
   void _activateOfflineMode() {
+    if (isOffline) return;
+
     /// Turn the offline mode on
     isOnlineNotifier.value = false;
 

--- a/lib/presentation/service/network_service_base.dart
+++ b/lib/presentation/service/network_service_base.dart
@@ -40,9 +40,6 @@ abstract base class NetworkServiceBase {
   /// Timer for background connection restore checker
   Timer? _timer;
 
-  /// Guard against concurrent timeout-triggered ping checks
-  bool _timeoutCheckInProgress = false;
-
   ///
   Future<void> prepare() async {
     if (_subscription != null) return;
@@ -124,31 +121,10 @@ abstract base class NetworkServiceBase {
     NetworkRestore() => _deactivateOfflineMode(),
     NetworkConnectionLost() => _activateOfflineMode(),
 
-    /// Timeout may indicate either a slow backend or a silently dropped
-    /// connection (e.g. iOS does not surface DNS failures as SocketException —
-    /// it reports them as TimeoutException). Confirm reachability with a
-    /// short ping and switch to offline mode if it fails.
-    NetworkRequestTimeout() => _checkReachabilityAfterTimeout(),
-
     /// All others don't matter here; they will be handled in the overridden
     /// function.
     _ => {},
   };
-
-  /// Performs a single ping when a request times out. If the backend remains
-  /// unreachable, activates offline mode. Skipped while already offline (the
-  /// periodic timer handles that case) or if a check is already running.
-  Future<void> _checkReachabilityAfterTimeout() async {
-    if (isOffline) return;
-    if (_timeoutCheckInProgress) return;
-    _timeoutCheckInProgress = true;
-    try {
-      final bool result = await sendPingRequest();
-      if (!result && isOnline) _activateOfflineMode();
-    } finally {
-      _timeoutCheckInProgress = false;
-    }
-  }
 
   ///
   bool get isWiFi => getIt<ConnectivityService>().isWiFi;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: application_base
 description: "Unified base for Flutter applications"
-version: 0.1.8
+version: 0.1.9
 homepage: https://github.com/AlexSeednov/application_base
 
 environment:


### PR DESCRIPTION
* `NetworkRequestTimeout` removed — request timeouts are now treated as a
  loss of connection and emit `NetworkConnectionLost` directly. This lets
  the offline mode activate even for silent/background requests without an
  extra reachability check.
* `NetworkServiceBase`: removed timeout-triggered ping fallback that became
  redundant after the change above.