### PR TITLE
Offline checker improved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.2.0
+
+* Offline mode now confirms backend reachability before switching back online
+  after connectivity returns, with serialized ping checks and restore logs.
+* New `NetworkConnectionAvailable` network event added - network interface 
+  is available, but backend availability is not confirmed.
+
 ## 0.1.9
 
 * `NetworkRequestTimeout` removed — request timeouts are now treated as a

--- a/lib/data/remote/const/network_event.dart
+++ b/lib/data/remote/const/network_event.dart
@@ -19,6 +19,12 @@ final class NetworkRestore extends NetworkEvent {
   NetworkRestore({super.data});
 }
 
+/// Network interface is available, but backend availability is not confirmed.
+final class NetworkConnectionAvailable extends NetworkEvent {
+  ///
+  NetworkConnectionAvailable({super.data});
+}
+
 /// There is no internet connection or backend is down. Also emitted on
 /// request timeouts — a timeout from the backend is treated as a temporary
 /// loss of connection and triggers the offline mode.

--- a/lib/data/remote/service/connectivity_service.dart
+++ b/lib/data/remote/service/connectivity_service.dart
@@ -77,7 +77,7 @@ final class ConnectivityService {
   void _check() {
     if (isConnectivityAvailable) {
       logInfo(info: 'Connectivity available');
-      _connectionSubject.add(NetworkSuccess());
+      _connectionSubject.add(NetworkConnectionAvailable());
     } else {
       logInfo(info: 'Connectivity not available');
       _connectionSubject.add(NetworkConnectionLost());

--- a/lib/presentation/service/network_service_base.dart
+++ b/lib/presentation/service/network_service_base.dart
@@ -41,6 +41,9 @@ abstract base class NetworkServiceBase {
   Timer? _timer;
 
   ///
+  bool _isPingInProgress = false;
+
+  ///
   Future<void> prepare() async {
     if (_subscription != null) return;
     _subscription = _networkSubject.listen(onUpdate);
@@ -49,8 +52,8 @@ abstract base class NetworkServiceBase {
     if (!_connectivityService.isConnectivityAvailable) return;
 
     ///
-    final bool result = await sendPingRequest();
-    if (!result) _activateOfflineMode();
+    final bool? result = await _checkBackendAvailability();
+    if (result == false) _activateOfflineMode();
   }
 
   ///
@@ -101,13 +104,45 @@ abstract base class NetworkServiceBase {
 
   ///
   Future<void> ping() async {
-    ///
-    final bool result = await sendPingRequest();
-    if (result) {
-      /// Send connection restore event to provide information about it for
-      /// all listeners, include this one
-      _networkSubject.add(NetworkRestore());
+    final bool? result = await _checkBackendAvailability();
+    if (result == null) return;
+
+    if (!result) {
+      logInfo(info: 'Ping failed');
+      _activateOfflineMode();
+      return;
     }
+
+    /// Send connection restore event to provide information about it for
+    /// all listeners, include this one
+    _networkSubject.add(NetworkRestore());
+  }
+
+  /// Return
+  ///   * `null` if ping is already in progress
+  ///   * `true` if backend is available
+  ///   * `false` otherwise.
+  Future<bool?> _checkBackendAvailability() async {
+    if (_isPingInProgress) return null;
+
+    _isPingInProgress = true;
+
+    /// [sendPingRequest] implementation may be not safe, so we need to catch
+    /// all possible errors here to prevent crashes.
+    try {
+      return await sendPingRequest();
+    } catch (error) {
+      logError(error: 'Ping request failed', additional: error.toString());
+      return false;
+    } finally {
+      _isPingInProgress = false;
+    }
+  }
+
+  ///
+  void _confirmConnectionRestore() {
+    logInfo(info: 'Connectivity available in offline mode, pinging backend');
+    unawaited(ping());
   }
 
   ///
@@ -116,6 +151,9 @@ abstract base class NetworkServiceBase {
   void onUpdate(NetworkEvent event) => switch (event) {
     /// Success
     NetworkSuccess() => _onlineMode(),
+
+    /// Connectivity
+    NetworkConnectionAvailable() when isOffline => _confirmConnectionRestore(),
 
     /// Connection
     NetworkRestore() => _deactivateOfflineMode(),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: application_base
 description: "Unified base for Flutter applications"
-version: 0.1.9
+version: 0.2.0
 homepage: https://github.com/AlexSeednov/application_base
 
 environment:


### PR DESCRIPTION
## 0.2.0

* Offline mode now confirms backend reachability before switching back online
  after connectivity returns, with serialized ping checks and restore logs.
* New `NetworkConnectionAvailable` network event added - network interface 
  is available, but backend availability is not confirmed.