### PR TITLE
Injectable integration, singletons update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 0.2.3
+
+* `NavigationServicePro` — injectable facade over the `navigation_service.dart`
+  helpers (`push` / `replace` / `replaceAll` / `navigate` / `pop` / `popForced`
+  / `popUntilRouteName` / `currentRouteName`) so view models depend on a
+  contract instead of the global-`navigatorKey` functions and navigation
+  branches can be tested with a recording fake. Contract lives in
+  `navigation_service_pro.dart`, the `NavigationServiceRouter` implementation in
+  `navigation_service_router.dart`. The package ships the classes but does not
+  register them — bind in the consumer's DI.
+* `UrlLauncherPro` — injectable facade over the static `UrlLauncher` (`open` /
+  `sendEmail` / `call` / `sendSms`) for the same testability reason. Contract
+  lives in `url_launcher_pro.dart`, the `UrlLauncherRouter` implementation in
+  `url_launcher_router.dart`. Ships the classes but does not register them —
+  bind in the consumer's DI.
+
 ## 0.2.2
 
 * `catchRedirect` now in try/catch with the same behaviour as a base sender.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,26 @@
 ## 0.2.3
 
+* **BREAKING — DI moved to injectable.** The package now registers its own
+  services through an injectable micro-package module
+  (`ApplicationBasePackageModule` in `service_locator.module.dart`) instead of
+  the manual `ServiceLocatorBase.prepare()` (class removed). Consumers wire it
+  via `externalPackageModulesBefore: [ExternalModule(ApplicationBasePackageModule)]`
+  in their `@InjectableInit`. `ApplicationBase.prepare()` no longer registers
+  dependencies — it is now a post-DI step (flavor + `LifecycleService.prepare()`)
+  and must be called AFTER the consumer's `getIt.init()`.
 * `NavigationServicePro` — injectable facade over the `navigation_service.dart`
   helpers (`push` / `replace` / `replaceAll` / `navigate` / `pop` / `popForced`
   / `popUntilRouteName` / `currentRouteName`) so view models depend on a
   contract instead of the global-`navigatorKey` functions and navigation
   branches can be tested with a recording fake. Contract lives in
   `navigation_service_pro.dart`, the `NavigationServiceRouter` implementation in
-  `navigation_service_router.dart`. The package ships the classes but does not
-  register them — bind in the consumer's DI.
+  `navigation_service_router.dart`. Registered by the package's injectable
+  module as `@LazySingleton(as: NavigationServicePro)`.
 * `UrlLauncherPro` — injectable facade over the static `UrlLauncher` (`open` /
   `sendEmail` / `call` / `sendSms`) for the same testability reason. Contract
   lives in `url_launcher_pro.dart`, the `UrlLauncherRouter` implementation in
-  `url_launcher_router.dart`. Ships the classes but does not register them —
-  bind in the consumer's DI.
+  `url_launcher_router.dart`. Registered by the package's injectable module as
+  `@LazySingleton(as: UrlLauncherPro)`.
 
 ## 0.2.2
 

--- a/README.md
+++ b/README.md
@@ -87,13 +87,13 @@ import 'package:application_base/core/service/service_locator.module.dart';
 @InjectableInit(
   externalPackageModulesBefore: [ExternalModule(ApplicationBasePackageModule)],
 )
-void configureDependencies() => getIt.init();
+Future<void> configureDependencies() => getIt.init();
 ```
 
-Then, on application launch, initialize dependency injection first and call
-`ApplicationBase.prepare();` afterwards — it runs a post-DI step (flavor +
-lifecycle) and resolves `getIt<LifecycleService>()`, so it must be called AFTER
-your `getIt.init()`.
+`getIt.init()` is asynchronous when external package modules are wired, so
+**await** it during launch. Call `ApplicationBase.prepare();` afterwards — it
+runs a post-DI step (flavor + lifecycle) and resolves `getIt<LifecycleService>()`,
+so it must run AFTER `getIt.init()` has completed.
 
 Important: do not forget to call `WidgetsFlutterBinding.ensureInitialized();` 
 before preparing.

--- a/README.md
+++ b/README.md
@@ -161,11 +161,10 @@ The package registers its own services through an injectable micro-package
 module (`ApplicationBasePackageModule`, generated into
 `service_locator.module.dart` — see [Usage](#usage) for wiring). Every service
 is a getIt-owned singleton: annotate the class with `@lazySingleton`, or with
-`@LazySingleton(as: Contract)` to bind a contract to its implementation. Legacy
-services keep a private constructor plus a `.singleton()` factory annotated with
-`@factoryMethod`, so injectable builds the single shared instance without a
-manual `_instance` handoff. Ownership is uniform, so individual classes don't
-repeat this note.
+`@LazySingleton(as: Contract)` to bind a contract to its implementation.
+Dependencies are passed through the constructor (constructor injection), which
+is marked `@visibleForTesting` so a second instance can't be created outside
+tests. Ownership is uniform, so individual classes don't repeat this note.
 
 1. Prepare GetIt:
 

--- a/README.md
+++ b/README.md
@@ -437,6 +437,39 @@ void logout(){
 }
 ```
 
+### NavigationServicePro (injectable facade)
+
+The top-level functions above read the global `navigatorKey`, which couples any
+view model that calls them to a mounted router. For testable navigation depend
+on the `NavigationServicePro` contract instead — in tests register a recording
+fake and assert navigation branches without pumping a widget tree.
+
+The contract (`push` / `replace` / `replaceAll` / `navigate` / `pop` /
+`popForced` / `popUntilRouteName` / `currentRouteName`) lives in
+`navigation_service_pro.dart`; the `NavigationServiceRouter` implementation in
+`navigation_service_router.dart`. The package ships both but **does not register
+them** — bind them in your project's DI. With `injectable`:
+
+```dart
+import 'package:application_base/data/remote/utility/url_launcher_pro.dart';
+import 'package:application_base/data/remote/utility/url_launcher_router.dart';
+import 'package:application_base/presentation/navigation/navigation_service_pro.dart';
+import 'package:application_base/presentation/navigation/navigation_service_router.dart';
+import 'package:injectable/injectable.dart';
+
+@module
+abstract class ServiceModule {
+  @lazySingleton
+  NavigationServicePro get navigation => NavigationServiceRouter();
+
+  @lazySingleton
+  UrlLauncherPro get urlLauncher => UrlLauncherRouter();
+}
+```
+
+or manually:
+`getIt.registerLazySingleton<NavigationServicePro>(NavigationServiceRouter.new)`.
+
 ## API interaction
 
 TBD
@@ -507,6 +540,12 @@ final bool emailResult = await UrlLauncher.launchSendMail(
       body: 'Strong email body!',
     );
 ```
+
+For testable link opening from view models use the `UrlLauncherPro` contract
+(`open` / `sendEmail` / `call` / `sendSms`) with its `UrlLauncherRouter`
+implementation instead of the static `UrlLauncher` — see
+[NavigationServicePro](#navigationservicepro-injectable-facade) for the DI
+binding pattern.
 
 ## Share
 

--- a/README.md
+++ b/README.md
@@ -77,8 +77,23 @@ dependencies:
     version: 0.1.3
 ```
 
-Now just call `ApplicationBase.prepare();` on application launching to 
-initialize all necessary data.
+The package registers its services through an injectable micro-package module.
+Wire it into your service locator by adding the module to your `@InjectableInit`:
+
+```dart
+import 'package:application_base/core/service/service_locator.dart';
+import 'package:application_base/core/service/service_locator.module.dart';
+
+@InjectableInit(
+  externalPackageModulesBefore: [ExternalModule(ApplicationBasePackageModule)],
+)
+void configureDependencies() => getIt.init();
+```
+
+Then, on application launch, initialize dependency injection first and call
+`ApplicationBase.prepare();` afterwards — it runs a post-DI step (flavor +
+lifecycle) and resolves `getIt<LifecycleService>()`, so it must be called AFTER
+your `getIt.init()`.
 
 Important: do not forget to call `WidgetsFlutterBinding.ensureInitialized();` 
 before preparing.
@@ -139,6 +154,18 @@ running. Just set it once when launching the application
 ## GetIt
 
 Based on [get_it](https://pub.dev/packages/get_it)
+
+### Package services
+
+The package registers its own services through an injectable micro-package
+module (`ApplicationBasePackageModule`, generated into
+`service_locator.module.dart` — see [Usage](#usage) for wiring). Every service
+is a getIt-owned singleton: annotate the class with `@lazySingleton`, or with
+`@LazySingleton(as: Contract)` to bind a contract to its implementation. Legacy
+services keep a private constructor plus a `.singleton()` factory annotated with
+`@factoryMethod`, so injectable builds the single shared instance without a
+manual `_instance` handoff. Ownership is uniform, so individual classes don't
+repeat this note.
 
 1. Prepare GetIt:
 

--- a/lib/application_base.dart
+++ b/lib/application_base.dart
@@ -4,12 +4,14 @@ import 'package:application_base/core/service/service_locator.dart';
 import 'package:application_base/presentation/service/lifecycle_service.dart';
 
 abstract final class ApplicationBase {
+  /// Post-DI package initialization.
   ///
+  /// Service registration is now performed by the injectable module
+  /// `ApplicationBasePackageModule` (wired via `externalPackageModulesBefore`
+  /// in the consumer's `@InjectableInit`), so this method must be called AFTER
+  /// the consumer's `getIt.init()` — it resolves `getIt<LifecycleService>()`.
   static void prepare({FlavorType? currentFlavor}) {
-    /// Setup service locator
-    ServiceLocatorBase.prepare();
-
-    /// Set flator
+    /// Set flavor
     if (currentFlavor != null) flavor = currentFlavor;
 
     /// Prepare services

--- a/lib/core/service/service_locator.dart
+++ b/lib/core/service/service_locator.dart
@@ -1,32 +1,16 @@
-import 'package:application_base/data/local/service/storage_service.dart';
-import 'package:application_base/data/remote/service/connectivity_service.dart';
-import 'package:application_base/domain/subject/network_subject.dart';
-import 'package:application_base/presentation/service/lifecycle_service.dart';
-import 'package:application_base/presentation/view_model/access_vm.dart';
 import 'package:get_it/get_it.dart';
+import 'package:injectable/injectable.dart';
 
 /// Common instance for service locator
 final getIt = GetIt.instance;
 
-abstract final class ServiceLocatorBase {
-  /// Setup service locator
-  static void prepare() {
-    getIt
-      /// Data layer
-      ..registerLazySingleton<ConnectivityService>(
-        ConnectivityService.singleton,
-        dispose: (service) => service.dispose(),
-      )
-      ..registerLazySingleton<NetworkSubject>(
-        NetworkSubject.singleton,
-        dispose: (service) => service.dispose(),
-      )
-      ..registerLazySingleton<StorageService>(StorageService.singleton)
-      /// Presentation layer
-      ..registerLazySingleton<LifecycleService>(
-        LifecycleService.singleton,
-        dispose: (service) => service.dispose(),
-      )
-      ..registerLazySingleton<AccessVM>(AccessVM.singleton);
-  }
-}
+/// Injectable micro-package module.
+///
+/// build_runner collects every `@injectable` service of the package into
+/// `service_locator.module.dart` (the `ApplicationBasePackageModule` class).
+/// Consumers wire it via `externalPackageModulesBefore` in their
+/// `@InjectableInit` — there is no manual registration
+/// (`ServiceLocatorBase.prepare`) anymore; getIt is the single source of
+/// singleton ownership.
+@InjectableInit.microPackage()
+void initApplicationBasePackage() {}

--- a/lib/core/service/service_locator.module.dart
+++ b/lib/core/service/service_locator.module.dart
@@ -29,23 +29,22 @@ class ApplicationBasePackageModule extends _i526.MicroPackageModule {
 // initializes the registration of main-scope dependencies inside of GetIt
   @override
   _i687.FutureOr<void> init(_i526.GetItHelper gh) {
-    gh.lazySingleton<_i431.StorageService>(
-        () => _i431.StorageService.singleton());
-    gh.lazySingleton<_i29.ConnectivityService>(
-      () => _i29.ConnectivityService.singleton(),
-      dispose: (i) => i.dispose(),
-    );
+    gh.lazySingleton<_i431.StorageService>(() => _i431.StorageService());
     gh.lazySingleton<_i657.NetworkSubject>(
-      () => _i657.NetworkSubject.singleton(),
+      () => _i657.NetworkSubject(),
       dispose: (i) => i.dispose(),
     );
-    gh.lazySingleton<_i198.LifecycleService>(
-      () => _i198.LifecycleService.singleton(),
-      dispose: (i) => i.dispose(),
-    );
-    gh.lazySingleton<_i1049.AccessVM>(() => _i1049.AccessVM.singleton());
+    gh.lazySingleton<_i1049.AccessVM>(() => _i1049.AccessVM());
     gh.lazySingleton<_i268.UrlLauncherPro>(() => _i635.UrlLauncherRouter());
     gh.lazySingleton<_i229.NavigationServicePro>(
         () => _i429.NavigationServiceRouter());
+    gh.lazySingleton<_i29.ConnectivityService>(
+      () => _i29.ConnectivityService(gh<_i657.NetworkSubject>()),
+      dispose: (i) => i.dispose(),
+    );
+    gh.lazySingleton<_i198.LifecycleService>(
+      () => _i198.LifecycleService(gh<_i29.ConnectivityService>()),
+      dispose: (i) => i.dispose(),
+    );
   }
 }

--- a/lib/core/service/service_locator.module.dart
+++ b/lib/core/service/service_locator.module.dart
@@ -1,0 +1,51 @@
+//@GeneratedMicroModule;ApplicationBasePackageModule;package:application_base/core/service/service_locator.module.dart
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// coverage:ignore-file
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:async' as _i687;
+
+import 'package:application_base/data/local/service/storage_service.dart'
+    as _i431;
+import 'package:application_base/data/remote/service/connectivity_service.dart'
+    as _i29;
+import 'package:application_base/data/remote/utility/url_launcher_pro.dart'
+    as _i268;
+import 'package:application_base/data/remote/utility/url_launcher_router.dart'
+    as _i635;
+import 'package:application_base/domain/subject/network_subject.dart' as _i657;
+import 'package:application_base/presentation/navigation/navigation_service_pro.dart'
+    as _i229;
+import 'package:application_base/presentation/navigation/navigation_service_router.dart'
+    as _i429;
+import 'package:application_base/presentation/service/lifecycle_service.dart'
+    as _i198;
+import 'package:application_base/presentation/view_model/access_vm.dart'
+    as _i1049;
+import 'package:injectable/injectable.dart' as _i526;
+
+class ApplicationBasePackageModule extends _i526.MicroPackageModule {
+// initializes the registration of main-scope dependencies inside of GetIt
+  @override
+  _i687.FutureOr<void> init(_i526.GetItHelper gh) {
+    gh.lazySingleton<_i431.StorageService>(
+        () => _i431.StorageService.singleton());
+    gh.lazySingleton<_i29.ConnectivityService>(
+      () => _i29.ConnectivityService.singleton(),
+      dispose: (i) => i.dispose(),
+    );
+    gh.lazySingleton<_i657.NetworkSubject>(
+      () => _i657.NetworkSubject.singleton(),
+      dispose: (i) => i.dispose(),
+    );
+    gh.lazySingleton<_i198.LifecycleService>(
+      () => _i198.LifecycleService.singleton(),
+      dispose: (i) => i.dispose(),
+    );
+    gh.lazySingleton<_i1049.AccessVM>(() => _i1049.AccessVM.singleton());
+    gh.lazySingleton<_i268.UrlLauncherPro>(() => _i635.UrlLauncherRouter());
+    gh.lazySingleton<_i229.NavigationServicePro>(
+        () => _i429.NavigationServiceRouter());
+  }
+}

--- a/lib/data/local/service/storage_service.dart
+++ b/lib/data/local/service/storage_service.dart
@@ -2,19 +2,14 @@ import 'package:application_base/core/mixin/logging_mixin.dart';
 import 'package:application_base/data/local/utility/secure_storage_utility.dart';
 import 'package:hive_ce_flutter/hive_flutter.dart';
 import 'package:injectable/injectable.dart';
+import 'package:meta/meta.dart';
 
 /// Singleton for working with secure local storage
 @lazySingleton
 final class StorageService with LoggingMixin {
   ///
-  StorageService._();
-
-  ///
-  @factoryMethod
-  factory StorageService.singleton() => _instance;
-
-  ///
-  static final _instance = StorageService._();
+  @visibleForTesting
+  StorageService();
 
   /// Name for logger
   @override

--- a/lib/data/local/service/storage_service.dart
+++ b/lib/data/local/service/storage_service.dart
@@ -1,13 +1,16 @@
 import 'package:application_base/core/mixin/logging_mixin.dart';
 import 'package:application_base/data/local/utility/secure_storage_utility.dart';
 import 'package:hive_ce_flutter/hive_flutter.dart';
+import 'package:injectable/injectable.dart';
 
 /// Singleton for working with secure local storage
+@lazySingleton
 final class StorageService with LoggingMixin {
   ///
   StorageService._();
 
   ///
+  @factoryMethod
   factory StorageService.singleton() => _instance;
 
   ///

--- a/lib/data/remote/service/connectivity_service.dart
+++ b/lib/data/remote/service/connectivity_service.dart
@@ -1,10 +1,10 @@
 import 'dart:async';
 
 import 'package:application_base/core/service/logger_service.dart';
-import 'package:application_base/core/service/service_locator.dart';
 import 'package:application_base/domain/subject/network_subject.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:injectable/injectable.dart';
+import 'package:meta/meta.dart';
 
 /// Connectivity changes are no longer communicated to Android apps
 /// in the background starting with Android O (8.0).
@@ -16,17 +16,11 @@ import 'package:injectable/injectable.dart';
 @lazySingleton
 final class ConnectivityService {
   ///
-  ConnectivityService._();
+  @visibleForTesting
+  ConnectivityService(this._connectionSubject);
 
   ///
-  @factoryMethod
-  factory ConnectivityService.singleton() => _instance;
-
-  ///
-  static final _instance = ConnectivityService._();
-
-  ///
-  final _connectionSubject = getIt<NetworkSubject>();
+  final NetworkSubject _connectionSubject;
 
   ///
   final List<ConnectivityResult> _connectivityList = [];

--- a/lib/data/remote/service/connectivity_service.dart
+++ b/lib/data/remote/service/connectivity_service.dart
@@ -4,6 +4,7 @@ import 'package:application_base/core/service/logger_service.dart';
 import 'package:application_base/core/service/service_locator.dart';
 import 'package:application_base/domain/subject/network_subject.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:injectable/injectable.dart';
 
 /// Connectivity changes are no longer communicated to Android apps
 /// in the background starting with Android O (8.0).
@@ -12,11 +13,13 @@ import 'package:connectivity_plus/connectivity_plus.dart';
 ///
 /// On iOS simulators, the connectivity types stream might not update
 /// when Wi-Fi status changes.
+@lazySingleton
 final class ConnectivityService {
   ///
   ConnectivityService._();
 
   ///
+  @factoryMethod
   factory ConnectivityService.singleton() => _instance;
 
   ///
@@ -54,6 +57,7 @@ final class ConnectivityService {
   }
 
   ///
+  @disposeMethod
   void dispose() {
     _subscription?.cancel();
 

--- a/lib/data/remote/utility/url_launcher.dart
+++ b/lib/data/remote/utility/url_launcher.dart
@@ -55,7 +55,7 @@ abstract final class UrlLauncher {
 
   /// Try to make a call via phone application.
   /// Return **true** on success
-  static Future<bool> makeCall(String number) => launchLink('tel:$number!');
+  static Future<bool> makeCall(String number) => launchLink('tel:$number');
 
   /// Try to send an sms via message application.
   /// Return **true** on success

--- a/lib/data/remote/utility/url_launcher_pro.dart
+++ b/lib/data/remote/utility/url_launcher_pro.dart
@@ -1,0 +1,27 @@
+/// Injectable facade over the static `UrlLauncher`.
+///
+/// Depending on this contract instead of the static `UrlLauncher` lets a
+/// project register a recording fake in tests and assert launch intents without
+/// hitting a platform channel. The default `UrlLauncherRouter` implementation
+/// ships in `url_launcher_router.dart` but is not registered — bind it in the
+/// consuming project's DI.
+///
+/// Every method returns `true` on success and `false` on failure, mirroring
+/// `UrlLauncher`.
+abstract interface class UrlLauncherPro {
+  /// Opens [url] in an external application.
+  Future<bool> open(String url);
+
+  /// Opens the email client prefilled with [to], [title] and [body].
+  Future<bool> sendEmail({
+    required String to,
+    required String title,
+    required String body,
+  });
+
+  /// Opens the phone dialer for [number].
+  Future<bool> call(String number);
+
+  /// Opens the messaging app with [text] prefilled.
+  Future<bool> sendSms(String text);
+}

--- a/lib/data/remote/utility/url_launcher_router.dart
+++ b/lib/data/remote/utility/url_launcher_router.dart
@@ -1,0 +1,30 @@
+import 'package:application_base/data/remote/utility/url_launcher.dart';
+import 'package:application_base/data/remote/utility/url_launcher_pro.dart';
+
+/// [UrlLauncherPro] backed by the static [UrlLauncher].
+///
+/// Thin adapter: every method delegates to the matching `UrlLauncher` helper.
+final class UrlLauncherRouter implements UrlLauncherPro {
+  ///
+  UrlLauncherRouter();
+
+  ///
+  @override
+  Future<bool> open(String url) => UrlLauncher.launchLink(url);
+
+  ///
+  @override
+  Future<bool> sendEmail({
+    required String to,
+    required String title,
+    required String body,
+  }) => UrlLauncher.sendEmail(to: to, title: title, body: body);
+
+  ///
+  @override
+  Future<bool> call(String number) => UrlLauncher.makeCall(number);
+
+  ///
+  @override
+  Future<bool> sendSms(String text) => UrlLauncher.sendSms(text);
+}

--- a/lib/data/remote/utility/url_launcher_router.dart
+++ b/lib/data/remote/utility/url_launcher_router.dart
@@ -1,9 +1,11 @@
 import 'package:application_base/data/remote/utility/url_launcher.dart';
 import 'package:application_base/data/remote/utility/url_launcher_pro.dart';
+import 'package:injectable/injectable.dart';
 
 /// [UrlLauncherPro] backed by the static [UrlLauncher].
 ///
 /// Thin adapter: every method delegates to the matching `UrlLauncher` helper.
+@LazySingleton(as: UrlLauncherPro)
 final class UrlLauncherRouter implements UrlLauncherPro {
   ///
   UrlLauncherRouter();

--- a/lib/domain/subject/network_subject.dart
+++ b/lib/domain/subject/network_subject.dart
@@ -1,16 +1,19 @@
 import 'dart:async';
 
 import 'package:application_base/data/remote/const/network_event.dart';
+import 'package:injectable/injectable.dart';
 import 'package:rxdart/rxdart.dart';
 
 export 'package:application_base/data/remote/const/network_event.dart';
 
 ///
+@lazySingleton
 final class NetworkSubject {
   ///
   NetworkSubject._();
 
   ///
+  @factoryMethod
   factory NetworkSubject.singleton() => _instance;
 
   ///
@@ -20,6 +23,7 @@ final class NetworkSubject {
   final _networkSubject = PublishSubject<NetworkEvent>();
 
   ///
+  @disposeMethod
   void dispose() {
     _networkSubject.close();
   }

--- a/lib/domain/subject/network_subject.dart
+++ b/lib/domain/subject/network_subject.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:application_base/data/remote/const/network_event.dart';
 import 'package:injectable/injectable.dart';
+import 'package:meta/meta.dart';
 import 'package:rxdart/rxdart.dart';
 
 export 'package:application_base/data/remote/const/network_event.dart';
@@ -10,14 +11,8 @@ export 'package:application_base/data/remote/const/network_event.dart';
 @lazySingleton
 final class NetworkSubject {
   ///
-  NetworkSubject._();
-
-  ///
-  @factoryMethod
-  factory NetworkSubject.singleton() => _instance;
-
-  ///
-  static final _instance = NetworkSubject._();
+  @visibleForTesting
+  NetworkSubject();
 
   ///
   final _networkSubject = PublishSubject<NetworkEvent>();

--- a/lib/presentation/navigation/navigation_service_pro.dart
+++ b/lib/presentation/navigation/navigation_service_pro.dart
@@ -1,0 +1,41 @@
+import 'package:auto_route/auto_route.dart';
+
+/// Injectable facade over the navigation helpers of `navigation_service.dart`.
+///
+/// The top-level navigation functions read the global `navigatorKey`, which
+/// couples any view model that calls them to a mounted router. Depending on
+/// this contract instead lets a project register a recording fake in tests and
+/// assert navigation branches without pumping a widget tree.
+///
+/// Only route-object (type-safe) navigation is exposed; string-path helpers
+/// (`pushNamed` / `navigatePath`) and low-level accessors (`actualContext` /
+/// `actualRouter` / `unfocus`) stay in `navigation_service.dart`. The default
+/// `NavigationServiceRouter` implementation ships in
+/// `navigation_service_router.dart` but is not registered — bind it in the
+/// consuming project's DI.
+abstract interface class NavigationServicePro {
+  /// Adds [route] to the screens stack (in-sector navigation).
+  Future<void> push(PageRouteInfo<dynamic> route);
+
+  /// Replaces the top screen with [route].
+  Future<void> replace(PageRouteInfo<dynamic> route);
+
+  /// Rebuilds the whole stack with [route] as its single entry.
+  Future<void> replaceAll(PageRouteInfo<dynamic> route);
+
+  /// Pops until [route] already exists in the stack, otherwise pushes it
+  /// (cross-sector navigation).
+  Future<void> navigate(PageRouteInfo<dynamic> route);
+
+  /// Pops the top screen unless it is the only entry, returning [result].
+  Future<void> pop({bool? result});
+
+  /// Pops the top screen regardless of whether it is the last one in the stack.
+  void popForced({bool? result});
+
+  /// Keeps popping routes until a route named [routeName] is on top.
+  void popUntilRouteName(String routeName);
+
+  /// Name of the current (top) route, or `null` if the router is unavailable.
+  String? get currentRouteName;
+}

--- a/lib/presentation/navigation/navigation_service_router.dart
+++ b/lib/presentation/navigation/navigation_service_router.dart
@@ -1,0 +1,50 @@
+import 'package:application_base/presentation/navigation/navigation_service.dart'
+    as base;
+import 'package:application_base/presentation/navigation/navigation_service_pro.dart';
+import 'package:auto_route/auto_route.dart';
+
+/// [NavigationServicePro] backed by the global `navigatorKey` via AutoRoute.
+///
+/// Thin adapter: every method delegates to the top-level helpers in
+/// `navigation_service.dart`.
+final class NavigationServiceRouter implements NavigationServicePro {
+  ///
+  NavigationServiceRouter();
+
+  ///
+  @override
+  Future<void> push(PageRouteInfo<dynamic> route) =>
+      base.pushScreen(route: route);
+
+  ///
+  @override
+  Future<void> replace(PageRouteInfo<dynamic> route) =>
+      base.replaceScreen(route: route);
+
+  ///
+  @override
+  Future<void> replaceAll(PageRouteInfo<dynamic> route) =>
+      base.replaceAllScreen(route: route);
+
+  ///
+  @override
+  Future<void> navigate(PageRouteInfo<dynamic> route) =>
+      base.navigateScreen(route: route);
+
+  ///
+  @override
+  Future<void> pop({bool? result}) => base.popScreen(result: result);
+
+  ///
+  @override
+  void popForced({bool? result}) => base.popScreenForced(result: result);
+
+  ///
+  @override
+  void popUntilRouteName(String routeName) =>
+      base.popUntilScreenWithName(routeName: routeName);
+
+  ///
+  @override
+  String? get currentRouteName => base.currentRouteName;
+}

--- a/lib/presentation/navigation/navigation_service_router.dart
+++ b/lib/presentation/navigation/navigation_service_router.dart
@@ -2,11 +2,13 @@ import 'package:application_base/presentation/navigation/navigation_service.dart
     as base;
 import 'package:application_base/presentation/navigation/navigation_service_pro.dart';
 import 'package:auto_route/auto_route.dart';
+import 'package:injectable/injectable.dart';
 
 /// [NavigationServicePro] backed by the global `navigatorKey` via AutoRoute.
 ///
 /// Thin adapter: every method delegates to the top-level helpers in
 /// `navigation_service.dart`.
+@LazySingleton(as: NavigationServicePro)
 final class NavigationServiceRouter implements NavigationServicePro {
   ///
   NavigationServiceRouter();

--- a/lib/presentation/service/lifecycle_service.dart
+++ b/lib/presentation/service/lifecycle_service.dart
@@ -4,14 +4,17 @@ import 'package:application_base/core/service/logger_service.dart';
 import 'package:application_base/core/service/service_locator.dart';
 import 'package:application_base/data/remote/service/connectivity_service.dart';
 import 'package:flutter/widgets.dart';
+import 'package:injectable/injectable.dart';
 import 'package:rxdart/rxdart.dart';
 
 ///
+@lazySingleton
 final class LifecycleService {
   ///
   LifecycleService._();
 
   ///
+  @factoryMethod
   factory LifecycleService.singleton() => _instance;
 
   ///
@@ -45,6 +48,7 @@ final class LifecycleService {
   }
 
   ///
+  @disposeMethod
   void dispose() {
     _listener?.dispose();
     _lifecycleSubject.close();

--- a/lib/presentation/service/lifecycle_service.dart
+++ b/lib/presentation/service/lifecycle_service.dart
@@ -1,27 +1,21 @@
 import 'dart:async';
 
 import 'package:application_base/core/service/logger_service.dart';
-import 'package:application_base/core/service/service_locator.dart';
 import 'package:application_base/data/remote/service/connectivity_service.dart';
 import 'package:flutter/widgets.dart';
 import 'package:injectable/injectable.dart';
+import 'package:meta/meta.dart';
 import 'package:rxdart/rxdart.dart';
 
 ///
 @lazySingleton
 final class LifecycleService {
   ///
-  LifecycleService._();
+  @visibleForTesting
+  LifecycleService(this._connectivityService);
 
   ///
-  @factoryMethod
-  factory LifecycleService.singleton() => _instance;
-
-  ///
-  static final _instance = LifecycleService._();
-
-  ///
-  final _connectivityService = getIt<ConnectivityService>();
+  final ConnectivityService _connectivityService;
 
   ///
   final _lifecycleSubject = PublishSubject<AppLifecycleState>();

--- a/lib/presentation/view_model/access_vm.dart
+++ b/lib/presentation/view_model/access_vm.dart
@@ -6,14 +6,8 @@ import 'package:injectable/injectable.dart';
 @lazySingleton
 final class AccessVM with ChangeNotifier {
   ///
-  AccessVM._();
-
-  ///
-  @factoryMethod
-  factory AccessVM.singleton() => _instance;
-
-  ///
-  static final _instance = AccessVM._();
+  @visibleForTesting
+  AccessVM();
 
   ///
   bool _isGranted = false;

--- a/lib/presentation/view_model/access_vm.dart
+++ b/lib/presentation/view_model/access_vm.dart
@@ -1,12 +1,15 @@
 import 'package:application_base/core/service/logger_service.dart';
 import 'package:flutter/foundation.dart';
+import 'package:injectable/injectable.dart';
 
 ///
+@lazySingleton
 final class AccessVM with ChangeNotifier {
   ///
   AccessVM._();
 
   ///
+  @factoryMethod
   factory AccessVM.singleton() => _instance;
 
   ///

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,7 +47,10 @@ dependencies:
 
   # All platform supported
   http: ^1.6.0
-  
+
+  # All platform supported
+  injectable: ^2.7.1
+
   # All platform supported
   logger: ^2.6.2
 
@@ -65,9 +68,15 @@ dependencies:
 
 #
 dev_dependencies:
+  # dart run build_runner build --delete-conflicting-outputs
+  build_runner: ^2.10.4
+
   #
   flutter_test:
     sdk: flutter
+
+  # dart run build_runner build --delete-conflicting-outputs
+  injectable_generator: ^2.12.0
 
 # Executables exposed by the package — invoked via `dart run application_base:<name>`.
 executables:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: application_base
 description: "Unified base for Flutter applications"
-version: 0.2.2
+version: 0.2.3
 homepage: https://github.com/AlexSeednov/application_base
 
 environment:


### PR DESCRIPTION
## 0.2.3

* **BREAKING — DI moved to injectable.** The package now registers its own
  services through an injectable micro-package module
  (`ApplicationBasePackageModule` in `service_locator.module.dart`) instead of
  the manual `ServiceLocatorBase.prepare()` (class removed). Consumers wire it
  via `externalPackageModulesBefore: [ExternalModule(ApplicationBasePackageModule)]`
  in their `@InjectableInit`. `ApplicationBase.prepare()` no longer registers
  dependencies — it is now a post-DI step (flavor + `LifecycleService.prepare()`)
  and must be called AFTER the consumer's `getIt.init()`.
* `NavigationServicePro` — injectable facade over the `navigation_service.dart`
  helpers (`push` / `replace` / `replaceAll` / `navigate` / `pop` / `popForced`
  / `popUntilRouteName` / `currentRouteName`) so view models depend on a
  contract instead of the global-`navigatorKey` functions and navigation
  branches can be tested with a recording fake. Contract lives in
  `navigation_service_pro.dart`, the `NavigationServiceRouter` implementation in
  `navigation_service_router.dart`. Registered by the package's injectable
  module as `@LazySingleton(as: NavigationServicePro)`.
* `UrlLauncherPro` — injectable facade over the static `UrlLauncher` (`open` /
  `sendEmail` / `call` / `sendSms`) for the same testability reason. Contract
  lives in `url_launcher_pro.dart`, the `UrlLauncherRouter` implementation in
  `url_launcher_router.dart`. Registered by the package's injectable module as
  `@LazySingleton(as: UrlLauncherPro)`.